### PR TITLE
chore: remove duplicate logic of createObj

### DIFF
--- a/js/send_order.js
+++ b/js/send_order.js
@@ -59,14 +59,6 @@ function sendOrder() {
   }
   var data = JSON.stringify(itemList);
   xhr.send(data);
-  // // jui edit
-  //     var jui = document.getElementsByClassName("item-data");
-  //     for (var i = 0 ; i < jui.length ; i++) {
-  //       itemData.item(i).getElementsByClassName("modelName")[0].value = "";
-  //       itemData.item(i).getElementsByClassName("blueprint")[0].value = "";
-  //       itemData.item(i).getElementsByClassName("quantity")[0].value = "";
-  //     }
-  // // jui edit end
 }
 
 function createObj() {


### PR DESCRIPTION
There are unused logic which is duplicate with `createObj`, so it make more sense to remove it.